### PR TITLE
fix: more precise base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5-240
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5-240.1648458092
 
 LABEL maintainer="Radio Bern RaBe"
 


### PR DESCRIPTION
Using a more precise base helps dependabot make us update the image as needed.