### PR TITLE
fix(CIS-DI-0006): remove unnecessary files in /tmp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,7 @@ LABEL maintainer="Radio Bern RaBe"
 
 # Add RaBe CA trust anchor
 COPY rabe/rabe-ca.crt /etc/pki/ca-trust/source/anchors/
-RUN update-ca-trust extract 
+
+RUN    update-ca-trust extract \
+       # CIS-DI-0006: no unnecessary files in /tmp \
+    && rm /tmp/ks-script-*


### PR DESCRIPTION
Remove some scripts that do some `restorecon` and are just a side-effect of how upstream RedHat builds the ubi8-minimal image.