### PR TITLE
fix: update base image from 8.6-751 to 8.6-751.1655117800

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-751
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-751.1655117800
 
 LABEL maintainer="Radio Bern RaBe"
 


### PR DESCRIPTION
* fixes #29 
* CVE-2022-1271