### PR TITLE
fix: update from 8.6-902 to 8.6-902.1661794353

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-902
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-902.1661794353
 
 LABEL maintainer="Radio Bern RaBe"
 


### PR DESCRIPTION
updates:

* tzdata-2022c-1.el8.noarch
* curl-7.61.1-22.el8_6.4.x86_64
* systemd-libs-239-58.el8_6.4.x86_64
* libcurl-7.61.1-22.el8_6.4.x86_64

reason that makes this worthwhile for us is curl.