### PR TITLE
chore(ci): introduce updatecli for base image bumps

### DIFF
--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -1,0 +1,29 @@
+on:
+  schedule:
+    - cron:  '13 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install jq in the runner
+        run: |
+          sudo apt-get update
+          sudo apt-get install jq
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@v2
+
+      - name: Run Updatecli in Dry Run mode
+        run: updatecli diff
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Updatecli in Apply mode
+        run: updatecli apply
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.RABE_ITREAKTION_GITHUB_TOKEN }}

--- a/hack/getLatestTagFromApi.sh
+++ b/hack/getLatestTagFromApi.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+#
+# Grab latest container image tag from Red Hat's API
+#
+# This scripts exists because it's easier to get the latest version from the API than to rely on rate-limited container registries for CI
+#
+
+set -xe -o pipefail
+
+curl -sL https://registry.access.redhat.com/v2/ubi8/ubi-minimal/tags/list | jq -r '.tags | .[]' | grep -v -P '(latest|source)' | sort | tail -1

--- a/updatecli.d/baseImage.yaml
+++ b/updatecli.d/baseImage.yaml
@@ -1,0 +1,15 @@
+---
+sources:
+  tagFromApi:
+    kind: shell
+    spec:
+      command: ./hack/getLatestTagFromApi.sh
+targets:
+  update:
+    name: "Update base image to latest version"
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "FROM"
+        matcher: "registry.access.redhat.com/ubi8/ubi-minimal"


### PR DESCRIPTION
This replaces dependabot with a solution that uses Red Hat's API instead of their rate-limited container registries and should hopefully be more reliable for our needs.